### PR TITLE
Fixup download.py and integrate it into bam.lua

### DIFF
--- a/bam.lua
+++ b/bam.lua
@@ -424,7 +424,7 @@ function GenerateSettings(conf, arch, builddir, compiler)
 	return settings
 end
 
--- String formatting wth named parameters, by RiciLake http://lua-users.org/wiki/StringInterpolation
+-- String formatting with named parameters, by RiciLake http://lua-users.org/wiki/StringInterpolation
 function interp(s, tab)
 	return (s:gsub('%%%((%a%w*)%)([-0-9%.]*[cdeEfgGiouxXsq])',
 			function(k, fmt)
@@ -489,9 +489,17 @@ for a, cur_arch in ipairs(archs) do
 		local settings = GenerateSettings(cur_conf, cur_arch, cur_builddir, compiler)
 		for t, cur_target in pairs(targets) do
 			table.insert(subtargets[cur_target], PathJoin(cur_builddir, cur_target .. settings.link.extension))
+			dl = Python("scripts/download.py")
+			dl = dl .. " -arch " .. cur_arch .. " -conf " .. cur_conf
+			AddJob(cur_target .. "SDL2.dll", "Downloading SDL2.dll for " .. cur_arch .. "/" .. cur_conf, dl .. " +pack SDL2.dll-" .. cur_arch)
+			AddJob(cur_target .. "freetype.dll", "Downloading freetype.dll for " .. cur_arch .. "/" .. cur_conf, dl .. " +pack freetype.dll-" .. cur_arch)
 		end
 	end
 end
+
+AddJob("other/sdl/include/SDL.h", "Downloading sdl and freetype", dl .. " +pack sdl +pack freetype")      --TODO: remove freetype from sdl-download
+AddJob("other/freetype/include/freetype.h", "Downloading freetype", dl .. " +pack freetype") --TODO: MAKE ME WORKING (why don't I...!?)
+
 for cur_name, cur_target in pairs(targets) do
 	-- Supertarget for all configurations and architectures of that target
 	PseudoTarget(cur_name, subtargets[cur_target])

--- a/bam.lua
+++ b/bam.lua
@@ -489,16 +489,20 @@ for a, cur_arch in ipairs(archs) do
 		local settings = GenerateSettings(cur_conf, cur_arch, cur_builddir, compiler)
 		for t, cur_target in pairs(targets) do
 			table.insert(subtargets[cur_target], PathJoin(cur_builddir, cur_target .. settings.link.extension))
-			dl = Python("scripts/download.py")
-			dl = dl .. " -arch " .. cur_arch .. " -conf " .. cur_conf
-			AddJob(cur_target .. "SDL2.dll", "Downloading SDL2.dll for " .. cur_arch .. "/" .. cur_conf, dl .. " +pack SDL2.dll-" .. cur_arch)
-			AddJob(cur_target .. "freetype.dll", "Downloading freetype.dll for " .. cur_arch .. "/" .. cur_conf, dl .. " +pack freetype.dll-" .. cur_arch)
+			if family == "windows" then
+				dl = Python("scripts/download.py")
+				dl = dl .. " --arch " .. cur_arch .. " --conf " .. cur_conf
+				AddJob(cur_target .. "SDL2.dll", "Downloading SDL2.dll for " .. cur_arch .. "/" .. cur_conf, dl .. " SDL2.dll")
+				AddJob(cur_target .. "freetype.dll", "Downloading freetype.dll for " .. cur_arch .. "/" .. cur_conf, dl .. " freetype.dll")
+			end
 		end
 	end
 end
 
-AddJob("other/sdl/include/SDL.h", "Downloading sdl and freetype", dl .. " +pack sdl +pack freetype")      --TODO: remove freetype from sdl-download
-AddJob("other/freetype/include/freetype.h", "Downloading freetype", dl .. " +pack freetype") --TODO: MAKE ME WORKING (why don't I...!?)
+if family == "windows" then
+	AddJob("other/sdl/include/SDL.h", "Downloading sdl and freetype", dl .. " sdl freetype") -- TODO: remove freetype from sdl-download
+	AddJob("other/freetype/include/freetype.h", "Downloading freetype", dl .. " freetype")   -- TODO: MAKE ME WORKING (why don't I...!?)
+end
 
 for cur_name, cur_target in pairs(targets) do
 	-- Supertarget for all configurations and architectures of that target

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -15,28 +15,29 @@ def _downloadZip(url, filePath):
         myzip.extractall(filePath)
     os.remove(temp_filePath)
 
-def downloadAll(arch, conf):
-    downloadUrl = "https://github.com/Zwelf/tw-downloads/raw/master/{}.zip"
-    builddir = "../build/" + arch + "/" + conf + "/"
-    files = (downloadUrl.format("SDL2.dll"     + "-" + arch), builddir            ),\
-            (downloadUrl.format("freetype.dll" + "-" + arch), builddir            ),\
-            (downloadUrl.format("sdl"                      ), "other/sdl/"     ),\
-            (downloadUrl.format("freetype"                 ), "other/freetype/")
-    for elem in files:
-        for i in range(1,len(sys.argv)):
-            sTmp = re.search('master/(.+?).zip', elem[0])
-            curr_pack = sTmp.group(1)
-            if sys.argv[i] == "+pack" and sys.argv[i + 1] == curr_pack:
-                _downloadZip(elem[0], elem[1])
+def downloadAll(arch, conf, targets):
+    download_url = "https://github.com/Zwelf/tw-downloads/raw/master/{}.zip".format
+    builddir = "build/" + arch + "/" + conf + "/"
+    files = {
+        "SDL2.dll":     ("SDL2.dll"     + "-" + arch, builddir),
+        "freetype.dll": ("freetype.dll" + "-" + arch, builddir),
+        "sdl":          ("sdl",                       "other/sdl/"),
+        "freetype":     ("freetype",                  "other/freetype/"),
+    }
+
+    for target in targets:
+        download_file, target_dir = files[target]
+        _downloadZip(download_url(download_file), target_dir)
 
 def main():
-    arch = "x86"
-    conf = "debug"
-    for i in range(1,len(sys.argv)): # this is expandable infinitly for more args
-        if sys.argv[i] == "-arch": arch = sys.argv[i + 1] 
-        if sys.argv[i] == "-conf": conf = sys.argv[i + 1]
+    import argparse
+    p = argparse.ArgumentParser(description="Download freetype and SDL library and header files for Windows.")
+    p.add_argument("--arch", default="x86", choices=["x86", "x86_64"], help="Architecture for the downloaded libraries (Default: x86)")
+    p.add_argument("--conf", default="debug", choices=["debug", "release"], help="Build type (Default: debug)")
+    p.add_argument("targets", metavar="TARGET", nargs='+', choices=["SDL.dll", "freetype.dll", "sdl", "freetype"], help='Target to download. Valid choices are "SDL.dll", "freetype.dll", "sdl" and "freetype"')
+    args = p.parse_args()
 
-    downloadAll(arch, conf)
+    downloadAll(args.arch, args.conf, args.targets)
 
 if __name__ == '__main__':
     main()

--- a/scripts/download.py
+++ b/scripts/download.py
@@ -2,6 +2,7 @@ import urllib.request
 import os
 import zipfile
 import sys
+import re
 
 def _downloadZip(url, filePath):
     # create full path, if it doesn't exists
@@ -19,14 +20,22 @@ def downloadAll(arch, conf):
     builddir = "../build/" + arch + "/" + conf + "/"
     files = (downloadUrl.format("SDL2.dll"     + "-" + arch), builddir            ),\
             (downloadUrl.format("freetype.dll" + "-" + arch), builddir            ),\
-            (downloadUrl.format("sdl"                      ), "../other/sdl/"     ),\
-            (downloadUrl.format("freetype"                 ), "../other/freetype/")
+            (downloadUrl.format("sdl"                      ), "other/sdl/"     ),\
+            (downloadUrl.format("freetype"                 ), "other/freetype/")
     for elem in files:
-        _downloadZip(elem[0], elem[1])
+        for i in range(1,len(sys.argv)):
+            sTmp = re.search('master/(.+?).zip', elem[0])
+            curr_pack = sTmp.group(1)
+            if sys.argv[i] == "+pack" and sys.argv[i + 1] == curr_pack:
+                _downloadZip(elem[0], elem[1])
 
 def main():
-    arch = sys.argv[1] if len(sys.argv) >= 2 else "x86"
-    conf = sys.argv[2] if len(sys.argv) >= 3 else "debug"
+    arch = "x86"
+    conf = "debug"
+    for i in range(1,len(sys.argv)): # this is expandable infinitly for more args
+        if sys.argv[i] == "-arch": arch = sys.argv[i + 1] 
+        if sys.argv[i] == "-conf": conf = sys.argv[i + 1]
+
     downloadAll(arch, conf)
 
 if __name__ == '__main__':


### PR DESCRIPTION
I felt so free to integrate your download.py into the bam.lua, but I'm sorry that I had to change your script so massively :)

What I did:

- Optimized commandline argumant parsing
- It now will only download what it is told to by the args
- - According to that I changed bam.lua in that way that it only tells the script to download the missing things

- - BUG: bam.lua won't realize a missing freetype, I have no clue why because for SDL, it works...
- ...And I fixed a bug in download.py which made it to download all the things to the directory *above* the working dir

__A short summary of how to use the Python-Script now:__

``download.py [-arch | -conf | +pack [pack]]``
Example: `download.py -arch x86 -conf debug +pack sdl +pack freetype.dll`
will download other/sdl and build/x86/debug/freetype.dll

The order of the arguments doesn't matter, because I rewrote the parsingcode.
``Example 2: download.py +pack sdl2.dll-x86 -arch x86 +pack freetype -conf debug``
would be also ok.